### PR TITLE
Move tests to autoload-dev section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,11 @@
     "license": "MIT",
     "autoload": {
         "psr-4": {
-            "Burtds\\VatChecker\\": "src/",
+            "Burtds\\VatChecker\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
             "Tests\\": "tests/"
         }
     },


### PR DESCRIPTION
Why: Classes needed to run the test suite should not be included in the main autoload rules to avoid polluting the autoloader in production and when other people use your package as a dependency.

see https://getcomposer.org/doc/04-schema.md#autoload-dev