### PR TITLE
Fix Laravel Matrix Version Testing in CI Workflow

### DIFF
--- a/.github/workflows/run-tests-pest.yml
+++ b/.github/workflows/run-tests-pest.yml
@@ -1,6 +1,6 @@
 name: Tests
 
-on: [push, pull_request]
+on: [ push, pull_request ]
 
 jobs:
   test:
@@ -8,20 +8,23 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, windows-latest]
-        php: [8.1, 8.2, 8.3, 8.4]
-        laravel: [9, 10, 11, 12]
-        stability: [prefer-lowest, prefer-stable]
+        os: [ ubuntu-latest, windows-latest ]
+        php: [ 8.1, 8.2, 8.3, 8.4 ]
+        laravel: [ 9, 10, 11, 12 ]
+        stability: [ prefer-lowest, prefer-stable ]
         exclude:
+          - php: 8.2
+            laravel: 9
+          - php: 8.3
+            laravel: 9
+          - php: 8.4
+            laravel: 9
           - php: 8.1
             laravel: 11
           - php: 8.1
             laravel: 12
-          - php: 8.1
-            laravel: 12
-          
 
-    name: P${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
     steps:
       - name: Checkout code
@@ -31,8 +34,9 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
+          extensions: bcmath, curl, dom, exif, fileinfo, gd, iconv, imagick, intl, libxml, mbstring, pdo, pdo_sqlite, soap, sqlite, zip
           coverage: none
+          tools: composer:v2
 
       - name: Setup problem matchers
         run: |
@@ -40,7 +44,7 @@ jobs:
           echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
       - name: Install dependencies
-        run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction
+        run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --with="illuminate/contract:^${{ matrix.laravel }}"
 
       - name: Execute tests
         run: vendor/bin/pest

--- a/composer.json
+++ b/composer.json
@@ -35,10 +35,10 @@
         "format": "vendor/bin/pint"
     },
     "require-dev": {
-        "pestphp/pest": "^2.0",
+        "laravel/pint": "^1.13",
         "orchestra/testbench": "^8.13|^9.0|^10.0",
-        "spatie/laravel-ray": "^1.33",
-        "laravel/pint": "^1.13"
+        "pestphp/pest": "^1.0|^2.0|^3.0",
+        "spatie/laravel-ray": "^1.33"
     },
     "config": {
         "allow-plugins": {


### PR DESCRIPTION
This PR corrects the CI workflow to actually test against the Laravel versions defined in the matrix. Previously, the Laravel version was unintentionally constrained by the PHP version, which prevented proper coverage of the matrix.

For example, in [this workflow run](https://github.com/BurtDS/laravel-vatnumber-checker/actions/runs/13650802655), none of the jobs used Laravel 12 regardless of the matrix configuration due to the missing `--with` directive in the composer update step.

This change updates the composer command to explicitly require the correct Laravel version via `--with="illuminate/contracts:^${{ matrix.laravel }}"`, allowing the matrix to function as intended and improving test coverage across supported Laravel versions.